### PR TITLE
Cs.alterations.wallet address

### DIFF
--- a/projects/AlgoFire-frontend/package-lock.json
+++ b/projects/AlgoFire-frontend/package-lock.json
@@ -18,6 +18,7 @@
         "notistack": "^3.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-qr-code": "^2.0.12",
         "tslib": "^2.6.2"
       },
       "devDependencies": {
@@ -7294,7 +7295,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8092,6 +8092,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -8143,6 +8160,12 @@
       "dependencies": {
         "qrcode-generator": "^1.4.3"
       }
+    },
+    "node_modules/qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
+      "license": "MIT"
     },
     "node_modules/qrcode-generator": {
       "version": "1.5.2",
@@ -8265,6 +8288,19 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-qr-code": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.18.tgz",
+      "integrity": "sha512-v1Jqz7urLMhkO6jkgJuBYhnqvXagzceg3qJUWayuCK/c6LTIonpWbwxR1f1APGd4xrW/QcQEovNrAojbUz65Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/projects/AlgoFire-frontend/package.json
+++ b/projects/AlgoFire-frontend/package.json
@@ -45,7 +45,8 @@
     "notistack": "^3.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "tslib": "^2.6.2"
+    "tslib": "^2.6.2",
+    "react-qr-code": "^2.0.12"
   },
   "scripts": {
     "generate:app-clients": "algokit project link --all",

--- a/projects/AlgoFire-frontend/src/App.tsx
+++ b/projects/AlgoFire-frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { SupportedWallet, useWallet, WalletId, WalletManager, WalletProvider } from '@txnlab/use-wallet-react'
 import { SnackbarProvider } from 'notistack'
 import React, { useEffect, useState } from 'react'
+import AddressQRModal from './components/AddressQRModal'
 import Home from './Home'
 import { ellipseAddress } from './utils/ellipseAddress'
 import { getAlgodConfigFromViteEnvironment, getKmdConfigFromViteEnvironment } from './utils/network/getAlgoClientConfigs'
@@ -70,6 +71,7 @@ function AccountInfo({
   const [algoPrice, setAlgoPrice] = React.useState<number | null>(null)
   const [copied, setCopied] = React.useState(false)
   const [error, setError] = React.useState(false)
+  const [qrOpen, setQrOpen] = React.useState(false)
 
   // Fetch ALGO balance (exposed for manual refresh on click)
   const fetchBalance = React.useCallback(async () => {
@@ -188,6 +190,9 @@ function AccountInfo({
     }
   }
 
+  const openQR = () => setQrOpen(true)
+  const closeQR = () => setQrOpen(false)
+
   const handleDisconnect = async () => {
     if (wallets) {
       const activeWallet = wallets.find((w) => w.isActive)
@@ -231,6 +236,11 @@ function AccountInfo({
         </button>
       </div>
       <span className="flex items-center text-gray-700 text-sm mb-1">
+        <button className="mr-2 p-1 rounded hover:bg-gray-200" onClick={openQR} title="Show address QR code">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+            <path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm6-2h2v4h4V3h2v6h-8V3zm8 8h-6v2h2v2h2v-2h2v-2zm0 4h-2v2h-2v2h4v-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5z" />
+          </svg>
+        </button>
         <a href={`${explorerBase}/${activeAddress}`} target="_blank" rel="noreferrer" title={activeAddress} className="hover:underline">
           {ellipseAddress(activeAddress, 7)}
         </a>
@@ -254,6 +264,16 @@ function AccountInfo({
           )}
         </button>
       </span>
+      <AddressQRModal
+        open={qrOpen}
+        onClose={closeQR}
+        address={activeAddress}
+        balanceAlgos={balance ?? undefined}
+        balanceUsd={usdDisplay ?? undefined}
+        networkLabel={selectedNetwork === 'mainnet' ? 'Mainnet' : 'Testnet'}
+        onRefreshBalance={fetchBalance}
+        loading={loading}
+      />
       <span className="text-gray-700 text-lg min-h-[1.5em] flex items-center">
         {loading ? <span className="loading loading-spinner loading-xs mr-2" /> : null}
         {!loading && !error && balance ? (

--- a/projects/AlgoFire-frontend/src/components/AddressQRModal.tsx
+++ b/projects/AlgoFire-frontend/src/components/AddressQRModal.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import QRCode from 'react-qr-code'
+
+interface AddressQRModalProps {
+  open: boolean
+  onClose: () => void
+  address: string
+  balanceAlgos?: string | null
+  balanceUsd?: string | null
+  networkLabel: string
+  onRefreshBalance?: () => void
+  loading?: boolean
+}
+
+export default function AddressQRModal({
+  open,
+  onClose,
+  address,
+  balanceAlgos,
+  balanceUsd,
+  networkLabel,
+  onRefreshBalance,
+  loading,
+}: AddressQRModalProps) {
+  const [copied, setCopied] = React.useState(false)
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(address)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1200)
+  }
+
+  return (
+    <dialog className={`modal ${open ? 'modal-open' : ''}`}>
+      <form method="dialog" className="modal-box max-w-md relative">
+        <button type="button" className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" title="Close" onClick={onClose}>
+          ✕
+        </button>
+
+        <div className="flex items-start justify-between mb-2 pr-8">
+          <div className="text-sm text-gray-500">Generated: {new Date().toLocaleDateString()}</div>
+        </div>
+
+        <div className="text-sm text-gray-600">Network: {networkLabel}</div>
+        <div className="mt-1 text-gray-800">
+          {typeof balanceAlgos === 'string' && (
+            <div>
+              Balance:{' '}
+              <button
+                type="button"
+                className="underline decoration-dotted text-teal-700 hover:text-teal-800 disabled:text-gray-400"
+                onClick={onRefreshBalance}
+                disabled={!onRefreshBalance || !!loading}
+                title="Refresh balance"
+              >
+                {loading ? '...' : balanceAlgos}
+              </button>{' '}
+              ALGO
+            </div>
+          )}
+          {typeof balanceUsd === 'string' && <div>Value: {balanceUsd}</div>}
+        </div>
+
+        <div className="w-full flex items-center justify-center my-6">
+          <div className="bg-white p-3 rounded-lg shadow border">
+            <QRCode value={address} size={220} />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between mt-2">
+          <code className="text-xs break-all text-gray-700">{address}</code>
+          <button type="button" className="ml-2 p-2 rounded hover:bg-gray-200" title="Copy address" onClick={handleCopy}>
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <rect x="9" y="9" width="13" height="13" rx="2" strokeWidth="2" stroke="currentColor" fill="none" />
+              <rect x="3" y="3" width="13" height="13" rx="2" strokeWidth="2" stroke="currentColor" fill="none" />
+            </svg>
+          </button>
+        </div>
+        {copied && <div className="mt-1 text-xs text-green-600">Copied!</div>}
+      </form>
+      <form method="dialog" className="modal-backdrop" onClick={onClose}>
+        <button aria-label="Close backdrop" />
+      </form>
+    </dialog>
+  )
+}


### PR DESCRIPTION
- **Manual balance refresh**
  - Exposed `fetchBalance` in `AccountInfo` and made the numeric balance text clickable to re-query the blockchain.
  - Fixed duplicate dollar sign in USD display by normalizing the value.
  - Files: `src/App.tsx`

- **QR code modal for wallet address**
  - Added `AddressQRModal` to display:
    - Network label (Mainnet/Testnet), balance, and USD value above a centered QR code
    - Address with copy icon below the QR
  - Integrated a QR icon next to the displayed address to open the modal.
  - Enabled closing via small ✕ button and by clicking outside the modal.
  - Allowed clicking the balance inside the modal to trigger a fresh on-chain balance query.
  - Files: `src/components/AddressQRModal.tsx`, `src/App.tsx`

- **Dependency**
  - Added `react-qr-code` to `package.json` (requires `npm install`).

- **UX polish**
  - Spinner/disabled states during refresh; consistent USD formatting.

- **Quality**
  - No linter errors on changed files.